### PR TITLE
add support for music playlist feeds (musicL)

### DIFF
--- a/src/routes/album/[albumId]/+page.js
+++ b/src/routes/album/[albumId]/+page.js
@@ -52,8 +52,18 @@ export async function load({ params, fetch }) {
 					feed.item.sort((a, b) => (a['itunes:episode'] > b['itunes:episode'] ? 1 : -1));
 				}
 			}
-			albumData.feed.songs = feed.item ? [].concat(feed.item) : [];
-			albumData.feed.live = [].concat(data.liveItem);
+
+			if (feed?.['podcast:medium'] === 'musicL') {
+				// music playlist feeds (musicL) can only contain remoteItems
+				albumData.feed.remoteSongs = [].concat(feed?.['podcast:remoteItem'] || []);
+				albumData.feed.songs = [];
+				albumData.feed.live = [];
+			} else {
+				albumData.feed.remoteSongs = [];
+				albumData.feed.songs = feed.item ? [].concat(feed.item) : [];
+				albumData.feed.live = [].concat(data.liveItem);
+			}
+
 			return { album: albumData.feed, redirect };
 		}
 	} catch (err) {

--- a/src/routes/album/[albumId]/+page.svelte
+++ b/src/routes/album/[albumId]/+page.svelte
@@ -8,6 +8,7 @@
 
 	import AddToLibraryButton from '$buttons/AddToLibraryButton.svelte';
 	import SongCard from './SongCard.svelte';
+	import RemoteSongCard from './RemoteSongCard.svelte';
 
 	import { selectedAlbum, posterSwiper, library } from '$/stores';
 
@@ -80,6 +81,10 @@
 		{#if $selectedAlbum.songs.length}
 			{#each $selectedAlbum.songs as song, index}
 				<SongCard {song} {index} />
+			{/each}
+		{:else if $selectedAlbum.remoteSongs.length}
+			{#each $selectedAlbum.remoteSongs as remoteSong, index}
+				<RemoteSongCard {remoteSong} {index} />
 			{/each}
 		{:else}
 			<p style="text-align:center">This album has no songs.</p>

--- a/src/routes/album/[albumId]/RemoteSongCard.svelte
+++ b/src/routes/album/[albumId]/RemoteSongCard.svelte
@@ -1,0 +1,233 @@
+<script>
+	import { parse } from 'fast-xml-parser';
+	import { decode } from 'html-entities';
+	import Play from '$icons/PlayArrow.svelte';
+	import Pause from '$icons/Pause.svelte';
+	import { onMount, onDestroy } from 'svelte';
+
+	import {
+		selectedAlbum,
+		posterSwiper,
+		top100Playing,
+		player,
+		remoteServer,
+		playingAlbum,
+		playingIndex,
+		playingSong,
+		valueTimeSplitBlock,
+		playFeatured,
+		lnbRadioPlaying,
+		remotePlaylistPlaying,
+		remotePlaylist,
+	} from '$/stores';
+
+	export let remoteSong;
+	export let index;
+
+	let root;
+	let songInfo = {};
+	let loaded = false;
+
+	const parserOptions = {
+		attributeNamePrefix: '@_',
+		//attrNodeName: false,
+		//textNodeName : "#text",
+		ignoreAttributes: false,
+		ignoreNameSpace: false,
+		attrValueProcessor: (val, attrName) => decode(val), //default is a=>a
+		tagValueProcessor: (val, tagName) => decode(val) //default is a=>a
+	};
+
+	let observer = new IntersectionObserver((entries) => {
+		entries.forEach((entry) => {
+			if (entry.isIntersecting) {
+				loadRemoteInfo(); // load info if within the viewport
+				observer.disconnect();
+			}
+		});
+	});
+
+	onMount(async () => {
+		observer.observe(root);
+
+		if ($playFeatured && index === 0) {
+			playSong();
+			$playFeatured = false;
+		}
+	});
+
+	onDestroy(() => {
+		observer.disconnect();
+	});
+
+	async function loadRemoteInfo() {
+		if (!remoteSong['@_feedGuid']) {
+			return;
+		}
+
+		let remoteInfo = await fetchRemoteItem(remoteSong['@_feedGuid'], remoteSong['@_itemGuid']);
+
+		if (!remoteInfo.episode || remoteInfo.episode.length === 0) {
+			let feedInfo = await fetchRemoteFeed(remoteSong['@_feedGuid'])
+
+			remoteInfo = {
+				episode: {
+					title: "Unknown",
+					feedTitle: feedInfo.feed.title,
+					image: feedInfo.feed.image,
+					podcastGuid: feedInfo.feed.podcastGuid,
+				}
+			};
+		}
+
+		songInfo = remoteInfo.episode || {};
+		loaded = true;
+	}
+
+	async function fetchRemoteItem(feedGuid, itemGuid) {
+		const itemsUrl =
+			remoteServer +
+			`api/queryindex?q=${encodeURIComponent(`episodes/byguid?podcastguid=${feedGuid}&guid=${itemGuid}`)}`;
+		const res = await fetch(itemsUrl);
+		return await res.json();
+	}
+
+	async function fetchRemoteFeed(feedGuid) {
+		const itemsUrl =
+			remoteServer +
+			`api/queryindex?q=${encodeURIComponent(`podcasts/byguid?guid=${feedGuid}`)}`;
+		const res = await fetch(itemsUrl);
+		return await res.json();
+	}
+
+	async function playSong() {
+		$top100Playing = false;
+		$lnbRadioPlaying = false;
+		$valueTimeSplitBlock = [];
+
+		const { podcastGuid, title } = songInfo;
+
+		if ($playingIndex === index) {
+			openPoster();
+			return;
+		}
+
+		const feedUrl =
+			remoteServer + `api/queryindex?q=${encodeURIComponent(`podcasts/byguid?guid=${podcastGuid}`)}`;
+
+		try {
+			const albumRes = await fetch(feedUrl);
+			let albumData = await albumRes.json();
+			if (!albumData.status) {
+				throw error(404, 'Not found');
+			}
+
+			console.log(albumData.feed.url);
+			const res = await fetch(remoteServer + `api/proxy?url=${albumData.feed.url}`);
+			let data = await res.text();
+
+			let xml2Json = parse(data, parserOptions);
+			let feed = xml2Json.rss.channel;
+
+			console.log(feed);
+
+			if (feed) {
+				if (feed.item?.[0]?.['podcast:episode']) {
+					feed.item.sort((a, b) => (a['podcast:episode'] > b['podcast:episode'] ? 1 : -1));
+				} else if (feed.item?.[0]?.['itunes:episode']) {
+					feed.item.sort((a, b) => (a['itunes:episode'] > b['itunes:episode'] ? 1 : -1));
+				}
+
+				albumData.feed.songs = [].concat(feed.item);
+				albumData.feed.live = data.liveItem ? [].concat(data.liveItem) : undefined;
+			}
+
+			$playingAlbum = albumData.feed;
+			console.log($playingAlbum);
+			$playingAlbum.title = $playingAlbum.title;
+			$playingAlbum.author = $playingAlbum.author;
+
+			const foundSong = $playingAlbum.songs.find((v) => {
+				return v.guid['#text'] === remoteSong['@_itemGuid'];
+			});
+
+			$player.pause();
+			$player.src = foundSong.enclosure['@_url'];
+			$playingSong = foundSong;
+			$playingIndex = index;
+
+			$remotePlaylist = $selectedAlbum.remoteSongs;
+			$remotePlaylistPlaying = true;
+
+			$player.play();
+
+			$player.paused = $player.paused;
+
+			openPoster();
+		} catch (err) {
+			console.log(err);
+		}
+	}
+
+	function openPoster() {
+		document.getElementById('poster-swiper').style.visibility = 'initial';
+		$posterSwiper.slideTo(1);
+		// setTimeout(() => $posterSwiper.slideTo(1), 1000);
+	}
+
+</script>
+
+<li bind:this={root} on:click={playSong}>
+	{#if $player && !$player.paused && index === $playingIndex && $remotePlaylistPlaying}
+		<Pause size="48" />
+	{:else}
+		<Play size="48" />
+	{/if}
+
+	{#if !loaded}
+		<img width="60" src="" />
+		Loading...
+	{:else}
+		<img width="60" src={songInfo.image || songInfo.feedImage} />
+
+		<song-info>
+			<p>{songInfo.title || remoteSong['@_itemGuid']}</p>
+			<p>{songInfo.feedTitle || remoteSong['@_feedGuid']}</p>
+		</song-info>
+	{/if}
+</li>
+
+<style>
+	song-info {
+		display: flex;
+		flex-direction: column;
+		flex: 1;
+	}
+
+	song-info > p:nth-of-type(2) {
+		padding-left: 12px;
+		font-size: 0.9em;
+		font-style: italic;
+	}
+
+	li {
+		display: flex;
+		list-style: none;
+		justify-content: flex-start;
+		border-bottom: 1px solid var(--color-text-2);
+		padding: 8px;
+		align-items: center;
+	}
+
+	p {
+		text-align: left;
+		width: 100%;
+		padding: 0;
+		margin: 0 0 0 12px;
+	}
+
+	img {
+		margin-left: 8px;
+	}
+
+</style>

--- a/src/routes/album/[albumId]/SongCard.svelte
+++ b/src/routes/album/[albumId]/SongCard.svelte
@@ -22,7 +22,8 @@
 		lnbRadioPlaying,
 		playingTranscript,
 		playingTranscriptText,
-		currentTranscriptIndex
+		currentTranscriptIndex,
+		remotePlaylistPlaying,
 	} from '$/stores';
 	import AddSongToPlaylist from '$c/CreatePlaylist/AddSongToPlaylist.svelte';
 	import RemoveConfirmModal from '$routes/library/RemoveConfirmModal.svelte';
@@ -44,6 +45,7 @@
 	async function playSong() {
 		$top100Playing = false;
 		$lnbRadioPlaying = false;
+		$remotePlaylistPlaying = false;
 		$valueTimeSplitBlock = [];
 		if (song['podcast:chapters']) {
 			fetch(remoteServer + `api/proxy?url=${encodeURIComponent(song['podcast:chapters']['@_url'])}`)

--- a/src/routes/components/Player/Player.svelte
+++ b/src/routes/components/Player/Player.svelte
@@ -31,7 +31,9 @@
 		lnbRadioAlbums,
 		favorites,
 		favoritesDB,
-		mediaSession
+		mediaSession,
+		remotePlaylistPlaying,
+		remotePlaylist,
 	} from '$/stores';
 
 	const parserOptions = {
@@ -61,13 +63,14 @@
 				($playingIndex >= 0 &&
 					($playingIndex < album?.songs?.length - 1 ||
 						($top100Playing && ($playingIndex - 1 < $top100.length || $top100Loop)) ||
-						($lnbRadioPlaying && $playingIndex < $lnbRadio.length - 1))) ||
+						($lnbRadioPlaying && $playingIndex < $lnbRadio.length - 1) ||
+						($remotePlaylistPlaying && $playingIndex < $remotePlaylist.length - 1))) ||
 				album.favorites
 			) {
 				$playingIndex = $playingIndex + 1;
 				let nextSong;
 				let _nextSong;
-				if ($top100Playing || $lnbRadioPlaying) {
+				if ($top100Playing || $lnbRadioPlaying || $remotePlaylistPlaying) {
 					let feedUrl;
 					if ($lnbRadioPlaying) {
 						_nextSong = $lnbRadio[$playingIndex];
@@ -84,6 +87,16 @@
 
 						_nextSong = $top100[$playingIndex - 1];
 						let feedGuid = _nextSong.feedGuid;
+						feedUrl =
+							remoteServer +
+							`api/queryindex?q=${encodeURIComponent(`podcasts/byguid?guid=${feedGuid}`)}`;
+					} else if ($remotePlaylistPlaying) {
+						if ($playingIndex === $remotePlaylist.length) {
+							$playingIndex = 1;
+						}
+
+						_nextSong = $remotePlaylist[$playingIndex];
+						let feedGuid = _nextSong['@_feedGuid'];
 						feedUrl =
 							remoteServer +
 							`api/queryindex?q=${encodeURIComponent(`podcasts/byguid?guid=${feedGuid}`)}`;
@@ -129,6 +142,10 @@
 							foundSong = $playingAlbum.songs.find((v) => {
 								return v.title == _nextSong.title;
 							});
+						} else if ($remotePlaylist) {
+							foundSong = $playingAlbum.songs.find(
+								(v) => v.guid['#text'] == _nextSong['@_itemGuid']
+							);
 						}
 
 						nextSong = foundSong;
@@ -463,20 +480,21 @@
 			let album = $playingAlbum;
 			let currentSong = $playingSong;
 			if (
-				(album.songs || $lnbRadioPlaying) &&
+				(album.songs || $lnbRadioPlaying || $remotePlaylistPlaying) &&
 				(currentSong?.enclosure || currentSong?.enclosure?.['@_url'])
 			) {
 				if (
 					($playingIndex >= 0 &&
 						($playingIndex < album?.songs?.length - 1 ||
 							($top100Playing && ($playingIndex - 1 < $top100.length || $top100Loop)) ||
-							($lnbRadioPlaying && $playingIndex < $lnbRadio.length - 1))) ||
+							($lnbRadioPlaying && $playingIndex < $lnbRadio.length - 1) ||
+							($remotePlaylistPlaying && $playingIndex < $remotePlaylist.length - 1))) ||
 					album.favorites
 				) {
 					$playingIndex = $playingIndex + 1;
 					let nextSong;
 					let _nextSong;
-					if ($top100Playing || $lnbRadioPlaying) {
+					if ($top100Playing || $lnbRadioPlaying || $remotePlaylistPlaying) {
 						let feedUrl;
 						if ($lnbRadioPlaying) {
 							_nextSong = $lnbRadio[$playingIndex];
@@ -493,6 +511,16 @@
 
 							_nextSong = $top100[$playingIndex - 1];
 							let feedGuid = _nextSong.feedGuid;
+							feedUrl =
+								remoteServer +
+								`api/queryindex?q=${encodeURIComponent(`podcasts/byguid?guid=${feedGuid}`)}`;
+						} else if ($remotePlaylistPlaying) {
+							if ($playingIndex === $remotePlaylist.length) {
+								$playingIndex = 1;
+							}
+
+							_nextSong = $remotePlaylist[$playingIndex];
+							let feedGuid = _nextSong['@_feedGuid'];
 							feedUrl =
 								remoteServer +
 								`api/queryindex?q=${encodeURIComponent(`podcasts/byguid?guid=${feedGuid}`)}`;
@@ -540,6 +568,10 @@
 								foundSong = $playingAlbum.songs.find((v) => {
 									return v.title == _nextSong.title;
 								});
+							} else if ($remotePlaylist) {
+								foundSong = $playingAlbum.songs.find(
+									(v) => v.guid['#text'] == _nextSong['@_itemGuid']
+								);
 							}
 
 							nextSong = foundSong;
@@ -594,7 +626,7 @@
 					$playingIndex = $playingIndex - 1;
 					let nextSong;
 					let _nextSong;
-					if ($top100Playing || $lnbRadioPlaying) {
+					if ($top100Playing || $lnbRadioPlaying || $remotePlaylistPlaying) {
 						let feedUrl;
 						if ($lnbRadioPlaying) {
 							_nextSong = $lnbRadio[$playingIndex];
@@ -609,8 +641,19 @@
 								$playingIndex = 1;
 							}
 
+
 							_nextSong = $top100[$playingIndex - 1];
 							let feedGuid = _nextSong.feedGuid;
+							feedUrl =
+								remoteServer +
+								`api/queryindex?q=${encodeURIComponent(`podcasts/byguid?guid=${feedGuid}`)}`;
+						} else if ($remotePlaylistPlaying) {
+							if ($playingIndex === $remotePlaylist.length) {
+								$playingIndex = 1;
+							}
+
+							_nextSong = $remotePlaylist[$playingIndex];
+							let feedGuid = _nextSong['@_feedGuid'];
 							feedUrl =
 								remoteServer +
 								`api/queryindex?q=${encodeURIComponent(`podcasts/byguid?guid=${feedGuid}`)}`;
@@ -658,6 +701,10 @@
 								foundSong = $playingAlbum.songs.find((v) => {
 									return v.title == _nextSong.title;
 								});
+							} else if ($remotePlaylist) {
+								foundSong = $playingAlbum.songs.find(
+									(v) => v.guid['#text'] == _nextSong['@_itemGuid']
+								);
 							}
 
 							nextSong = foundSong;

--- a/src/routes/components/buttons/player/PreviousSong.svelte
+++ b/src/routes/components/buttons/player/PreviousSong.svelte
@@ -16,7 +16,9 @@
 		lnbRadioPlaying,
 		lnbRadio,
 		favorites,
-		favoritesDB
+		favoritesDB,
+		remotePlaylistPlaying,
+		remotePlaylist,
 	} from '$/stores';
 
 	const parserOptions = {
@@ -49,12 +51,13 @@
 		} else {
 			let album = $playingAlbum;
 			let currentSong = $playingSong;
+
 			if (album?.songs && (currentSong?.enclosure || currentSong?.enclosure?.['@_url'])) {
 				if ($playingIndex > 0 || album.favorites) {
 					$playingIndex = $playingIndex - 1;
 					let nextSong;
 					let _nextSong;
-					if ($top100Playing || $lnbRadioPlaying) {
+					if ($top100Playing || $lnbRadioPlaying || $remotePlaylistPlaying) {
 						let feedUrl;
 						if ($lnbRadioPlaying) {
 							_nextSong = $lnbRadio[$playingIndex];
@@ -69,8 +72,19 @@
 								$playingIndex = 1;
 							}
 
+
 							_nextSong = $top100[$playingIndex - 1];
 							let feedGuid = _nextSong.feedGuid;
+							feedUrl =
+								remoteServer +
+								`api/queryindex?q=${encodeURIComponent(`podcasts/byguid?guid=${feedGuid}`)}`;
+						} else if ($remotePlaylistPlaying) {
+							if ($playingIndex === $remotePlaylist.length) {
+								$playingIndex = 1;
+							}
+
+							_nextSong = $remotePlaylist[$playingIndex];
+							let feedGuid = _nextSong['@_feedGuid'];
 							feedUrl =
 								remoteServer +
 								`api/queryindex?q=${encodeURIComponent(`podcasts/byguid?guid=${feedGuid}`)}`;
@@ -118,6 +132,10 @@
 								foundSong = $playingAlbum.songs.find((v) => {
 									return v.title == _nextSong.title;
 								});
+							} else if ($remotePlaylist) {
+								foundSong = $playingAlbum.songs.find(
+									(v) => v.guid['#text'] == _nextSong['@_itemGuid']
+								);
 							}
 
 							nextSong = foundSong;

--- a/src/routes/playlist/favorites/+page.svelte
+++ b/src/routes/playlist/favorites/+page.svelte
@@ -24,7 +24,8 @@
 		lnbRadioPlaying,
 		playingTranscript,
 		playingTranscriptText,
-		currentTranscriptIndex
+		currentTranscriptIndex,
+		remotePlaylistPlaying,
 	} from '$/stores';
 	import AddSongToPlaylist from '$c/CreatePlaylist/AddSongToPlaylist.svelte';
 	import RemoveConfirmModal from '$routes/library/RemoveConfirmModal.svelte';
@@ -49,6 +50,7 @@
 		console.log(song);
 		$top100Playing = false;
 		$lnbRadioPlaying = false;
+		$remotePlaylistPlaying = false;
 		if (song['podcast:chapters']) {
 			fetch(remoteServer + `api/proxy?url=${encodeURIComponent(song['podcast:chapters']['@_url'])}`)
 				.then((res) => res.json())

--- a/src/routes/radio/+page.svelte
+++ b/src/routes/radio/+page.svelte
@@ -28,7 +28,8 @@
 		discoverList,
 		playingTranscript,
 		playingTranscriptText,
-		currentTranscriptIndex
+		currentTranscriptIndex,
+		remotePlaylistPlaying,
 	} from '$/stores';
 
 	let showAppSupport = false;
@@ -84,6 +85,8 @@
 		}
 
 		$top100Playing = false;
+		$remotePlaylistPlaying = false;
+
 		if (song['podcast:chapters']) {
 			fetch(remoteServer + `api/proxy?url=${encodeURIComponent(song['podcast:chapters']['@_url'])}`)
 				.then((res) => res.json())

--- a/src/routes/top100/+page.svelte
+++ b/src/routes/top100/+page.svelte
@@ -24,7 +24,8 @@
 		playingSong,
 		sortedTop100,
 		top100Loop,
-		valueTimeSplitBlock
+		valueTimeSplitBlock,
+		remotePlaylistPlaying,
 	} from '$/stores';
 
 	let expandMenu = false;
@@ -64,6 +65,7 @@
 
 	async function playSong(song) {
 		$top100Playing = true;
+		$remotePlaylistPlaying = false;
 		$valueTimeSplitBlock = [];
 		console.log(song);
 		console.log($top100Playing);

--- a/src/store/stores.js
+++ b/src/store/stores.js
@@ -69,3 +69,6 @@ export const lnbRadioPlaying = writable(false);
 export const playFeatured = writable(false);
 export const shareUrl = writable(false);
 export const shareText = writable('');
+
+export const remotePlaylist = writable([]);
+export const remotePlaylistPlaying = writable(false);


### PR DESCRIPTION
Checks the album feed for the musicL medium and uses the RemoteSongCard component to load and display the names of each playlist item. The rest of the code was borrowed from the top 100 code and follows a similar loading pattern.

![image](https://github.com/user-attachments/assets/a2dbaea4-7f0f-4b67-9c9b-6f85222e8d7b)
