### PR TITLE
Fix transcript errors

### DIFF
--- a/src/functions/loadSong.js
+++ b/src/functions/loadSong.js
@@ -38,7 +38,7 @@ export default async function loadSong(song) {
 		let res = await fetch(
 			remoteServer + `api/proxy?url=${encodeURIComponent(song['podcast:transcript']['@_url'])}`
 		);
-		let data = await res.text();
+		let data = (res.ok ? await res.text() : '');
 		playingTranscriptText.set(data);
 		// playingChapters.set(data?.chapters);
 	}

--- a/src/functions/loadSong.js
+++ b/src/functions/loadSong.js
@@ -30,13 +30,20 @@ export default async function loadSong(song) {
 		playingChapters.set(data?.chapters);
 	}
 
-	if (song?.['podcast:transcript']) {
+	if (
+		song?.['podcast:transcript'] &&
+		(song?.['podcast:transcript']['@_type'] === 'application/srt' ||
+			song?.['podcast:transcript']['@_type'] === 'application/x-rip')
+	) {
 		let res = await fetch(
 			remoteServer + `api/proxy?url=${encodeURIComponent(song['podcast:transcript']['@_url'])}`
 		);
 		let data = await res.text();
 		playingTranscriptText.set(data);
 		// playingChapters.set(data?.chapters);
+	}
+	else {
+		playingTranscriptText.set('');
 	}
 
 	const splits = song?.['podcast:value']?.['podcast:valueTimeSplit'] || [];

--- a/src/routes/album/[albumId]/SongCard.svelte
+++ b/src/routes/album/[albumId]/SongCard.svelte
@@ -65,7 +65,7 @@
 			fetch(
 				remoteServer + `api/proxy?url=${encodeURIComponent(song['podcast:transcript']['@_url'])}`
 			)
-				.then((res) => res.text())
+				.then((res) => (res.ok ? res.text() : ''))
 				.then((data) => ($playingTranscriptText = data));
 		} else {
 			$playingTranscript = [];

--- a/src/routes/album/[albumId]/[songId]/+page.svelte
+++ b/src/routes/album/[albumId]/[songId]/+page.svelte
@@ -67,7 +67,7 @@
 			fetch(
 				remoteServer + `api/proxy?url=${encodeURIComponent(song['podcast:transcript']['@_url'])}`
 			)
-				.then((res) => res.text())
+				.then((res) => (res.ok ? res.text() : ''))
 				.then((data) => ($playingTranscriptText = data));
 		} else {
 			$playingTranscript = [];

--- a/src/routes/playlist/favorites/+page.svelte
+++ b/src/routes/playlist/favorites/+page.svelte
@@ -69,7 +69,7 @@
 			fetch(
 				remoteServer + `api/proxy?url=${encodeURIComponent(song['podcast:transcript']['@_url'])}`
 			)
-				.then((res) => res.text())
+				.then((res) => (res.ok ? res.text() : ''))
 				.then((data) => ($playingTranscriptText = data))
 				.then(() => console.log($playingTranscriptText));
 		} else {

--- a/src/routes/radio/+page.svelte
+++ b/src/routes/radio/+page.svelte
@@ -105,7 +105,7 @@
 			fetch(
 				remoteServer + `api/proxy?url=${encodeURIComponent(song['podcast:transcript']['@_url'])}`
 			)
-				.then((res) => res.text())
+				.then((res) => (res.ok ? res.text() : ''))
 				.then((data) => ($playingTranscriptText = data))
 				.then(() => console.log($playingTranscriptText));
 		} else {


### PR DESCRIPTION
This PR fixes two issues with transcripts that I've recently noticed:

* Too Many Pieces - Circle the Earth from the Top 100 playlist causes the interface to freeze because the feed specifies a plain text transcript that LN Beats assumes is an SRT file. The PR adds a mime check to make sure the file is an SRT file.

* Lightning Thrashes Episode 65 causes the interface to freeze because the feed specifies a transcript file that doesn't exist. The code tries to pass "An error occurred while fetching the URL" as a transcript to parseSRT, which makes it unhappy. The PR checks if the load succeeded before using the text as a transcript