### PR TITLE
Fix payments to single split feeds

### DIFF
--- a/src/functions/sendBoost.js
+++ b/src/functions/sendBoost.js
@@ -18,7 +18,15 @@ export default async function sendBoost({
 	lockedSplit
 }) {
 	destinations = clone(destinations);
+
+	// the xml parser returns an object if the feed has one split and an array if the feed has multiple splits
+	// check if destinations is an object and convert it to an array
+	if (typeof destinations === 'object' && !Array.isArray(destinations) && destinations !== null) {
+		destinations = [destinations];
+	}
+
 	console.log(destinations);
+
 	let hasPI = destinations.find(
 		(v) => v['@_address'] === '03ae9f91a0cb8ff43840e3c322c4c61f019d8c1c3cea15a25cfc425ac605e61a4a'
 	);


### PR DESCRIPTION
This fixes an issue caused by the javascript XML parser, which seems to encode feeds with one split has objects and feeds with multiple splits as arrays of objects. This is most noticeable on the Wavlake feeds, which all have only one split in the feed.

Attempts to boost a feed/song that has only one split causes this check to fail in sendBoost since it's expecting an array and not an object: https://github.com/thebells1111/lnbeats/blob/949dc6bcbe12ebe6bd6ea0ef8c2a76ba5a2fdbd1/src/functions/sendBoost.js#L22

This PR checks if `destinations` is an object and converts it into an array as expected by the code.